### PR TITLE
Added clarifying remarks to instructions

### DIFF
--- a/migrate-mariadb-to-mariadbent.html.md.erb
+++ b/migrate-mariadb-to-mariadbent.html.md.erb
@@ -77,7 +77,11 @@ $ mysqldump --protocol TCP --port 13000 --user &lt;old-db-username&gt; --passwor
 Enter password: &lt;old-db-password&gt;
 </pre>
 
-After the dump has successfully been created, please open the /tmp/my-db-dump.sql file and make sure the last line is something like `-- Dump completed on 2017-08-15 11:06:17`.
+After the dump has successfully been created, please make sure the last line is something like `-- Dump completed on 2017-08-15 11:06:17` by running the following command:
+
+<pre class="terminal">
+$ tail -f /tmp/my-db-dump.sql
+</pre>
 
 Next, create an SSH tunnel to the new MariaDB. Open the terminal where you have the SSH connection open, press `ctrl+c` of `ctrl+d` and run the following command:
 

--- a/migrate-mariadb-to-mariadbent.html.md.erb
+++ b/migrate-mariadb-to-mariadbent.html.md.erb
@@ -77,15 +77,15 @@ $ mysqldump --protocol TCP --port 13000 --user &lt;old-db-username&gt; --passwor
 Enter password: &lt;old-db-password&gt;
 </pre>
 
-Please make sure the last line is something like `-- Dump completed on 2017-08-15 11:06:17`.
+After the dump has successfully been created, please open the /tmp/my-db-dump.sql file and make sure the last line is something like `-- Dump completed on 2017-08-15 11:06:17`.
 
-Next, create an SSH tunnel to the new MariaDB. Open the terminal where you have the SSH connection open, press `ctrl+c` and run the following command:
+Next, create an SSH tunnel to the new MariaDB. Open the terminal where you have the SSH connection open, press `ctrl+c` of `ctrl+d` and run the following command:
 
 <pre class="terminal">
 $ cf ssh proxy-app -L 13000:&lt;new-db-host&gt;:&lt;new-db-port&gt;
 </pre>
 
-Now we'll use the `mysql` CLI to restore the dump we created in the new MariaDB:
+Now we'll use the `mysql` CLI to restore the dump we created in the new MariaDB. Switch back to your other terminal and run:
 
 <pre class="terminal">
 mysql --protocol TCP --port 13000 --user &lt;new-db-username&gt; --password --show-warnings &lt;new-db-database&gt; &lt; /tmp/my-db-dump.sql
@@ -128,7 +128,7 @@ $ cf restage my-awesome-app
 As soon as everything is working properly, you can remove the service keys and the old database:
 
 <pre class="terminal">
-$ cf delete-service-key my-old migration
+$ cf delete-service-key my-db migration
 $ cf delete-service-key my-db-old migration
 $ cf delete-service my-db-old
 </pre>


### PR DESCRIPTION
Line 80: Specified that you need to open the created .sql file in order to check for the line `--Dump completed on 2017-08-15 11:06:17`, otherwise you might expect it to be shown in the terminal
Line 82: Added ctrl+d since ctrl+c did not work to close the SSH connection
Line 88: Specified that you need to switch to the other terminal again to restore the created dump in the new MariaDB
Line 131: changed my-old to my-db since this placeholder had been used throughout the entire documentation to ensure consistency.