### PR TITLE
Removed erroneous reference to MariaDB

### DIFF
--- a/migrate-redis-to-kubernetes-based-redis.html.md.erb
+++ b/migrate-redis-to-kubernetes-based-redis.html.md.erb
@@ -96,7 +96,7 @@ $ cf rename-service my-redis my-redis-old
 $ cf rename-service my-redis-new my-redis
 </pre>
 
-Now it's time to start your app again with the new MariaDB
+Now it's time to start your app again with the new Redis
 
 <pre class="terminal">
 $ cf start my-awesome-app


### PR DESCRIPTION
Removed erroneous reference to MariaDB in Redis guide (copy / paste error).