### PR TITLE
Update ECS API link to version 3.1

### DIFF
--- a/dynamic-storage.html.md.erb
+++ b/dynamic-storage.html.md.erb
@@ -160,7 +160,7 @@ When using ECS, the <strong>Access Key ID corresponds to <Namespace-Account></st
 
 #### More details
 
-To get more information about the underlying EMC ECS product, please consult their [documentation](https://www.emc.com/techpubs/api/ecs/v3-0-0-0/index.htm).
+To get more information about the underlying EMC ECS product, please consult their [REST API documentation](http://doc.isilon.com/ECS/3.1/API/index.html).
 
 ### <a id='unsupported'></a> The following operations are unsupported: (these functions are used very rarely)
 


### PR DESCRIPTION
We currently have version 3.1 of ECS - the link to the ECS API was still pointing to 3.0.