### PR TITLE
Recommend minor elasticsearch upgrade before major upgrade

### DIFF
--- a/elasticsearch.html.md.erb
+++ b/elasticsearch.html.md.erb
@@ -92,7 +92,8 @@ The upgrade to the new version is done through the CF CLI by running the update 
 
 ### Upgrade to Elasticsearch version 7.x
 
-Before you can upgrade to the latest major release of Elasticsearch (version 7) you must check for any incompatibilities of your exisitng indices.
+Before you can upgrade to the latest major release of Elasticsearch (version 7) you must check for any incompatibilities of your existing indices.
+We recommend first upgrading to the latest minor release of Elasticsearch version 6 (currently version 6.8.2) and then upgrade to version 7.x.
 Currently the upgrade assistant is not available.
 
 ## <a id='plan-upgrade'></a> Plan Upgrade


### PR DESCRIPTION
Since elasticsearch upgrades from 6.1.x to 7.3.x fail, we should specifically recommend upgrading to the latest minor release before upgrading to the latest major release.