### PR TITLE
Increase kibana disk quota

### DIFF
--- a/kibana-docker.html.md.erb
+++ b/kibana-docker.html.md.erb
@@ -31,8 +31,8 @@ Replace name, route, Kibana version, credentials in our example manifest.yml:
 ```txt
 applications:
   - name: mykibana
-	memory: 2G
-	disk_quota: 2G
+    memory: 2G
+    disk_quota: 2G
     instances: 1
     routes:
       - route: mykibana.scapp.io

--- a/kibana-docker.html.md.erb
+++ b/kibana-docker.html.md.erb
@@ -31,7 +31,8 @@ Replace name, route, Kibana version, credentials in our example manifest.yml:
 ```txt
 applications:
   - name: mykibana
-    memory: 2G
+	memory: 2G
+	disk_quota: 2G
     instances: 1
     routes:
       - route: mykibana.scapp.io


### PR DESCRIPTION
**Problem**
While pushing a kibana app as described in this guide, I got following error:
```
2019-11-04T11:55:15.21+0100 [API/2] OUT App instance exited with guid b51d6db1-486f-436a-8662-b6cfd1b22d7e payload: {"instance"=>"8c1e575b-0b47-42fb-5b55-52a6", "index"=>0, "cell_id"=>"d9659fa9-3a60-49b1-9aca-ff66e90de65e", "reason
"=>"CRASHED", "exit_description"=>"failed to create container: running image plugin create: pulling the image: streaming blob `sha256:cf46ff553bf144313e541e0ca0fc382bae7b09481f7dcb2db85471d3a2817f10`: writing blob to tempfile: uncompr
essed layer size exceeds quota\n: exit status 1", "crash_count"=>5, "crash_timestamp"=>1572864915067785161, "version"=>"16f8dc05-3049-440a-9518-fec8ad7471b4"}
```
Stating that the quota is reached.

**Proposed solution**
Increasing the disk_quota to `2 G` (default is value `1 G`) fixed the issue. Checking afterwards showed that the app is using 1.1G.